### PR TITLE
Fix an error by installing nvidia-modprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To build images, simply run:
 $ git clone https://github.com/uchida/packer-nvidia-docker
 $ cd packer-nvidia-docker
 $ export AWS_ACCESS_KEY_ID=xxx
-$ export AWS_SECRET_KEY_ID=xxx
+$ export AWS_SECRET_ACCESS_KEY=xxx
 $ packer build template.json
 ```
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,36 +2,35 @@
 
 - hosts: all
   vars:
-    nvidia_driver_version: 378
-    nvidia_docker_package_url: https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0/nvidia-docker_1.0.0-1_amd64.deb
+    nvidia_driver_version: 375
+    nvidia_docker_package_url: https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
   become: yes
   tasks:
     - name: packages related for APT with https are installed
       apt:
-        name={{ item }}
-        state=present
+        name: '{{ item }}'
+        state: present
       with_items:
         - apt-transport-https
         - ca-certificates
 
     - name: docker release key is registered
       apt_key:
-        keyserver=hkp://p80.pool.sks-keyservers.net:80
-        id=58118E89F3A912897C070ADBF76221572C52609D
-        state=present
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
 
     - name: software-properties-common is installed for prerequisite for apt_repository ansible module
       apt:
-        name=software-properties-common
-        state=present
+        name: software-properties-common
+        state: present
 
     - name: docker APT repository is registered
       apt_repository:
-        repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
-        filename=docker
-        state=present
-        mode=0644
-        update_cache=yes
+        repo: 'deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable'
+        filename: docker
+        state: present
+        mode: 0644
+        update_cache: yes
       failed_when: ansible_distribution_release not in ['precise', 'trusty', 'wily', 'xenial']
 
     - name: lxc-docker is purged
@@ -42,36 +41,42 @@
 
     - name: linux-image-extra is installed
       apt:
-        name=linux-image-extra-{{ ansible_kernel }}
-        state=present
+        name: 'linux-image-extra-{{ ansible_kernel }}'
+        state: present
       failed_when: ansible_distribution_release not in ['trusty', 'wily', 'xenial']
 
     - name: docker is installed
       apt:
-        name=docker-engine
-        state=present
+        name: 'docker-ce=17.03.0~ce-0~ubuntu-{{ ansible_kernel }}'
+        state: present
+      failed_when: ansible_distribution_release not in ['trusty', 'wily', 'xenial']
 
     - name: graphics-driver ppa APT repository is registered
       apt_repository:
-        repo=ppa:graphics-drivers/ppa
-        filename=graphic-driver
-        state=present
-        mode=0644
-        update_cache=yes
+        repo: ppa:graphics-drivers/ppa
+        filename: graphic-driver
+        state: present
+        mode: 0644
+        update_cache: yes
+
+    - name: nvidia-modprobe is installed
+      apt:
+        name: nvidia-modprobe
+        state: present
 
     - name: NVIDIA graphics driver {{ nvidia_driver_version }} is installed
       apt:
-        name=nvidia-{{ nvidia_driver_version }}
-        state=present
+        name: 'nvidia-{{ nvidia_driver_version }}'
+        state: present
 
     - name: disable nonveau, opensource version of nvidia graphics driver
       lineinfile:
-        dest=/etc/default/grub
-        line='GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nouveau.modeset=0"'
-        validate='sh -n %s'
+        dest: /etc/default/grub
+        line: 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nouveau.modeset=0"'
+        validate: 'sh -n %s'
 
     - name: nvidia-docker is installed
       apt:
-        deb={{ nvidia_docker_package_url }}
-        state=present
+        deb: '{{ nvidia_docker_package_url }}'
+        state: present
 

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ex
 apt-get update
-apt-get upgrade -y
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -yq
 echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_SECRET_KEY_ID`}}",
     "region": "ap-northeast-1",
-    "source_ami": "ami-b7d829d6",
+    "source_ami": "ami-1de1df7a",
     "spot_price": "0"
   },
   "builders": [


### PR DESCRIPTION
- Fix an error by installing nvidia-modprobe
- Use 20170516 Ubuntu image
- Change driver version to 375 (If I use 378, I get `modprobe: ERROR: could not insert 'nvidia_378': No such device`...)